### PR TITLE
extract arguments from event instance in a backward-compatible way

### DIFF
--- a/Indexer.module
+++ b/Indexer.module
@@ -166,7 +166,9 @@ class Indexer extends WireData implements Module, ConfigurableModule {
             
         require_once 'import/Pdf2txt.php';
         
-        $page = &$event->arguments[0]; 
+        $args = $event->arguments;
+        if (!isset($args[0])) return $event;
+        $page = $args[0];
         
         // don't add this to the admin pages
         if($page->template == 'admin') return $event;


### PR DESCRIPTION
I just did a little update for the __indexObject() method of the module.
I experienced some overloading warnings using php5.3.16 in combination with the repeater module.
